### PR TITLE
Add order sync update setting

### DIFF
--- a/app/addons/sd_odoo_integration/addon.xml
+++ b/app/addons/sd_odoo_integration/addon.xml
@@ -41,6 +41,10 @@
                         <type>template</type>
                         <default_value>cron_delete.tpl</default_value>
                     </item>
+                    <item id="import_new_odoo_orders">
+                        <type>checkbox</type>
+                        <default_value>Y</default_value>
+                    </item>
                 </items>
             </section>
         </sections>

--- a/app/addons/sd_odoo_integration/schemas/odoo/odoo_order_fields.php
+++ b/app/addons/sd_odoo_integration/schemas/odoo/odoo_order_fields.php
@@ -18,7 +18,10 @@ $schema = [
     'partner_shipping_id',
     'order_line',
     'display_name',
+    'invoice_status',
+    'payment_state',
     'picking_ids',
+    'write_date',
 ];
 
 return $schema;

--- a/var/langs/en/addons/sd_odoo_integration.po
+++ b/var/langs/en/addons/sd_odoo_integration.po
@@ -231,3 +231,7 @@ msgstr "Last status"
 msgctxt "Languages::sd_odoo_integration.odoo_error_create_product_double_sku"
 msgid "More than one product with this SKU was found in odoo, please check the SKU in the product"
 msgstr "More than one product with this SKU was found in odoo, please check the SKU in the product"
+
+msgctxt "Languages::sd_odoo_integration.import_new_odoo_orders"
+msgid "Import new orders from Odoo"
+msgstr "Import new orders from Odoo"


### PR DESCRIPTION
## Summary
- add new addon setting `import_new_odoo_orders`
- expand imported fields for Odoo orders
- update order sync logic to respect new setting and update existing orders
- implement helper to update existing CS-Cart orders with new status and shipment info

## Testing
- `git status --short`
