### PR TITLE
Add setting to prevent product deletions in Odoo

### DIFF
--- a/app/addons/sd_odoo_integration/addon.xml
+++ b/app/addons/sd_odoo_integration/addon.xml
@@ -45,6 +45,10 @@
                         <type>checkbox</type>
                         <default_value>Y</default_value>
                     </item>
+                    <item id="allow_delete_product_odoo">
+                        <type>checkbox</type>
+                        <default_value>N</default_value>
+                    </item>
                 </items>
             </section>
         </sections>

--- a/app/addons/sd_odoo_integration/src/HookHandlers/ProductHookHandler.php
+++ b/app/addons/sd_odoo_integration/src/HookHandlers/ProductHookHandler.php
@@ -13,6 +13,8 @@ namespace Tygh\Addons\SdOdooIntegration\HookHandlers;
 use Tygh\Addons\SdOdooIntegration\Exceptions\OdooException;
 use Tygh\Application;
 use Tygh\Registry;
+use Tygh\Settings;
+use Tygh\Enum\YesNo;
 use Tygh\Tygh;
 
 /**
@@ -60,6 +62,12 @@ class ProductHookHandler
     public function deleteProductPost(int $product_id, bool $product_deleted): void
     {
         if (!$product_deleted) {
+            return;
+        }
+
+        $settings = Settings::instance()->getValues('sd_odoo_integration', 'ADDON');
+        $allow_delete = $settings['general']['allow_delete_product_odoo'] ?? YesNo::NO;
+        if ($allow_delete !== YesNo::YES) {
             return;
         }
 

--- a/var/langs/en/addons/sd_odoo_integration.po
+++ b/var/langs/en/addons/sd_odoo_integration.po
@@ -235,3 +235,8 @@ msgstr "More than one product with this SKU was found in odoo, please check the 
 msgctxt "Languages::sd_odoo_integration.import_new_odoo_orders"
 msgid "Import new orders from Odoo"
 msgstr "Import new orders from Odoo"
+
+msgctxt "Languages::sd_odoo_integration.allow_delete_product_odoo"
+msgid "Allow product deletion in Odoo from CS-Cart?"
+msgstr "Allow product deletion in Odoo from CS-Cart?"
+


### PR DESCRIPTION
## Summary
- add new addon setting `allow_delete_product_odoo`
- skip Odoo product deletion unless this setting is enabled
- provide language entry for the new setting

## Testing
- `php` not available; no tests run