### PR TITLE
Fix return placement in import_all_product

### DIFF
--- a/app/addons/sd_odoo_integration/controllers/backend/odoo.php
+++ b/app/addons/sd_odoo_integration/controllers/backend/odoo.php
@@ -106,9 +106,9 @@ if ($mode == 'import') {
         fn_log_event('general', 'runtime', [
             'message' => __('sd_odoo_integration.successfully_completed'),
         ]);
-
-        return [CONTROLLER_STATUS_NO_CONTENT];
     }
+
+    return [CONTROLLER_STATUS_NO_CONTENT];
 } elseif ($mode == 'deleting') {
     if (
         !isset($_REQUEST['cron_password']) || empty($_REQUEST['cron_password']) ||


### PR DESCRIPTION
## Summary
- handle all companies during `import_all_product`

## Testing
- `php -l app/addons/sd_odoo_integration/controllers/backend/odoo.php` *(fails: command not found)*